### PR TITLE
fix: refresh the page to load two chapter

### DIFF
--- a/src/views/Chapter.vue
+++ b/src/views/Chapter.vue
@@ -460,10 +460,12 @@ export default {
     },
     //监听页面位置
     handleScroll: throttle(function() {
+      if (this.loading.visible) return;
+
       let doc = document.documentElement;
       let scrollTop = doc.scrollTop,
         clientHeight = doc.clientHeight,
-        scrollHeight = doc.scrollHeight;
+        scrollHeight = this.$refs.content.scrollHeight;
       let offset = scrollTop - this.oldScrollTop;
       //下滑到底部1/10加载一章
       if (offset > 0 && scrollTop + clientHeight >= 0.9 * scrollHeight) {


### PR DESCRIPTION
Fix refreshing the page loads two chapters. close https://github.com/gedoor/legado/issues/1896 
Fix refreshing the page to load the next chapter directly automatically.
