### PR TITLE
fix: hide book info that is too long

### DIFF
--- a/src/views/Index.vue
+++ b/src/views/Index.vue
@@ -455,7 +455,8 @@ export default {
             height: 112px;
             margin-left: 20px;
             flex: 1;
-
+            overflow: hidden;
+            
             .name {
               width: fit-content;
               font-size: 16px;


### PR DESCRIPTION
![{9A7A8276-C1AB-4e40-B7AF-7A9DE1C031C7}](https://github.com/gedoor/legado_web_bookshelf/assets/36879029/dfeb6dd3-62f1-48bd-931b-824975527670)

Fix too long chapter names.

当书籍章节名称过长时，会溢出并影响书籍列表布局，修复此bug。